### PR TITLE
use normalized profile values

### DIFF
--- a/playwright-tests/tests/friendStatus.e2e.test.js
+++ b/playwright-tests/tests/friendStatus.e2e.test.js
@@ -142,11 +142,11 @@ test.describe('Friend Status E2E', () => {
 
     test('Friend: A fills profile, sets status Friend, B sees full profile', async ({ users }) => {
         const { a, b } = users;
-        const name = a.username + 'Name';
-        const email = a.username + '@example.com';
-        const phone = '5555555555';
-        const linkedin = a.username + 'LinkedIn';
-        const x = a.username + 'X';
+        const name = "Testername";
+        const email = "tester@example.com";
+        const phone = "5555555";
+        const linkedin = "testerlinkedin";
+        const x = "testerx";
 
         // User A fills out profile
         await a.page.click('#toggleMenu');

--- a/playwright-tests/tests/smoke.e2e.test.js
+++ b/playwright-tests/tests/smoke.e2e.test.js
@@ -28,7 +28,7 @@ test.describe('Tests requiring recipient user', () => {
     await page.click('#newChatButton');
     await expect(page.locator('#newChatModal')).toBeVisible();
 
-    await page.type('#chatRecipient', recipient);
+    await page.fill('#chatRecipient', recipient);
     await page.waitForTimeout(3_000);
     const recipientStatus = await page.locator('#chatRecipientError').textContent().catch(() => '');
     expect(recipientStatus).toBe('found');
@@ -39,7 +39,7 @@ test.describe('Tests requiring recipient user', () => {
 
     await expect(page.locator('#chatModal')).toBeVisible();
     const testMessage = 'Hello from E2E test!'
-    await page.type('#chatModal .message-input', testMessage);
+    await page.fill('#chatModal .message-input', testMessage);
     await page.click('#handleSendMessage');
     await page.waitForTimeout(3_000);
 
@@ -63,7 +63,7 @@ test.describe('Tests requiring recipient user', () => {
     // Open New Chat 
     await page.click('#newChatButton');
     await expect(page.locator('#newChatModal')).toBeVisible();
-    await page.type('#chatRecipient', recipient);
+    await page.fill('#chatRecipient', recipient);
     await page.waitForTimeout(3_000);
     const recipientStatus = await page.locator('#chatRecipientError').textContent().catch(() => '');
     expect(recipientStatus).toBe('found');
@@ -138,11 +138,11 @@ test('Should set toll', async ({ page }) => {
 });
 
 test('Should update profile', async ({ page, username }) => {
-  const name = username + "Name";
-  const email = username + "@example.com";
-  const phone = '5555555555';
-  const linkedin = username + "LinkedIn";
-  const x = username + "X";
+  const name = "Testername";
+  const email = "tester@example.com";
+  const phone = "5555555";
+  const linkedin = "testerlinkedin";
+  const x = "testerx";
   await page.locator('#toggleMenu').click();
   await page.getByText('Profile', { exact: true }).click();
   await page.locator('#name').fill(name);


### PR DESCRIPTION
Profile edit test now expect the normalized profile field values. 
In response to webclient update https://github.com/Liberdus/web-client-v2/pull/336

also changed some page.type to page.fill since .type is deprecated 