### PR TITLE
Test for failed send asset keeps form filled

### DIFF
--- a/playwright-tests/tests/friendStatus.e2e.test.js
+++ b/playwright-tests/tests/friendStatus.e2e.test.js
@@ -300,9 +300,10 @@ test.describe('Friend Status E2E', () => {
         const memo = 'test memo 123';
 
         const tollTxProcessed = b.page.waitForEvent('console', {
+            timeout: 30_000,
             predicate: msg =>
-                msg.text().toLowerCase().includes('toll transaction successfully processed'),
-        }, { timeout: 30_000 });
+                /toll transaction successfully processed/i.test(msg.text())
+        });
 
         // User A opens wallet and prepares send form
         await a.page.click('#switchToWallet');

--- a/playwright-tests/tests/friendStatus.e2e.test.js
+++ b/playwright-tests/tests/friendStatus.e2e.test.js
@@ -3,7 +3,6 @@ const { createAndSignInUser, generateUsername } = require('../helpers/userHelper
 const { getLiberdusBalance } = require('../helpers/walletHelpers');
 const { sendMessageTo } = require('../helpers/messageHelpers');
 const networkParams = require('../helpers/networkParams');
-const { time } = require('console');
 
 // Constants
 const NETWORK_FEE = networkParams.networkFee;

--- a/playwright-tests/tests/friendStatus.e2e.test.js
+++ b/playwright-tests/tests/friendStatus.e2e.test.js
@@ -347,5 +347,6 @@ test.describe('Friend Status E2E', () => {
         await expect(a.page.locator('#sendToAddress')).toHaveValue(b.username);
         await expect(a.page.locator('#sendAmount')).toHaveValue(sendAmount);
         await expect(a.page.locator('#sendMemo')).toHaveValue(memo);
+        await expect(a.page.locator('#tollMemo')).toHaveText(/^toll: 5/i);
     });
 });


### PR DESCRIPTION
This PR adds 1 new test. User fills out send form, then toll is changed to required the send will fail on the confirmation screen, but when going back to Send Asset screen the previous values are preserved