### PR TITLE
Add validator market price e2e coverage

### DIFF
--- a/playwright-tests/tests/validator.e2e.test.js
+++ b/playwright-tests/tests/validator.e2e.test.js
@@ -1,0 +1,36 @@
+const { test: base, expect } = require('../fixtures/base');
+const { createAndSignInUser, generateUsername } = require('../helpers/userHelpers');
+const { newContext } = require('../helpers/toastHelpers');
+const networkParams = require('../helpers/networkParams');
+
+const test = base.extend({
+    user: async ({ browser, browserName }, use) => {
+        const context = await newContext(browser);
+        const page = await context.newPage();
+        const username = generateUsername(browserName);
+
+        await createAndSignInUser(page, username);
+
+        await use({ page, username, context });
+
+        await context.close();
+    }
+});
+
+test('validator market price uses stability factor', async ({ user }) => {
+    const { page } = user;
+
+    await page.locator('#toggleMenu').click();
+    await expect(page.locator('#menuModal')).toBeVisible();
+
+    await page.locator('#openValidator').click();
+    await expect(page.locator('#validatorModal')).toBeVisible();
+
+    const expectedFactor = networkParams.stabilityFactor.toFixed(6);
+    const expectedMarketPrice = `$${expectedFactor}`;
+
+    await expect(page.locator('#validator-stability-factor')).toHaveText(expectedFactor, { timeout: 30_000 });
+    await expect(page.locator('#validator-market-price')).toHaveText(expectedMarketPrice);
+    await expect(page.locator('#validator-network-stake-usd')).toContainText('$');
+    await expect(page.locator('#validator-network-stake-lib')).not.toHaveText('N/A');
+});


### PR DESCRIPTION
## Summary
- Add a validator e2e test that opens the validator modal and verifies the Market Price value matches the cached network stability factor
- Assert validator network stake fields are populated

## Notes
This test covers the frontend pricing change in Liberdus/web-client-v2#1309 using user-visible validator pricing output.

## Validation
- `node --check playwright-tests/tests/validator.e2e.test.js`
- `git diff --check`
- `npx playwright test tests/validator.e2e.test.js --project=chromium --list`
- Localhost run against `http://localhost:5500/`: `npx playwright test tests/validator.e2e.test.js --config=<temporary localhost config> --project=chromium` passed