### PR TITLE
Wait for named attachment downloads in Playwright tests

### DIFF
--- a/playwright-tests/tests/attachments.e2e.test.js
+++ b/playwright-tests/tests/attachments.e2e.test.js
@@ -5,6 +5,12 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
+function waitForNamedDownload(page, expectedFileName) {
+  return page.waitForEvent('download', {
+    predicate: download => download.suggestedFilename() === expectedFileName
+  });
+}
+
 // Helper to create test files with unique names based on test info to avoid conflicts in parallel runs
 async function createTestFile(baseFileName, sizeInMB = 0.5, type = 'image/png', uniqueId) {
   // Generate a unique filename by adding the unique ID before the extension
@@ -280,8 +286,8 @@ test.describe('File Attachment Tests', () => {
     const fileName = fileInfo.fileName;
     const testFilePath = fileInfo.filePath;
 
-    // Start waiting for download before clicking
-    const downloadPromise = page.waitForEvent('download');
+    // Start waiting for the named download before clicking
+    const downloadPromise = waitForNamedDownload(page, fileName);
 
     // Open New Chat
     await page.click('#newChatButton');
@@ -392,8 +398,8 @@ test.describe('File Attachment Tests', () => {
     const recipientPage = await testRecipient.context.newPage();
 
     try {
-      // Start waiting for download before clicking
-      const downloadPromise = recipientPage.waitForEvent('download');
+      // Start waiting for the named download before clicking
+      const downloadPromise = waitForNamedDownload(recipientPage, fileName);
       
       // Sign in as recipient
       await recipientPage.goto('');
@@ -548,7 +554,7 @@ test.describe('File Attachment Tests', () => {
         await expect(attachmentLink).toBeVisible({ timeout: 15000 });
         
         // Set up download listener for this specific attachment
-        const downloadPromise = recipientPage.waitForEvent('download');
+        const downloadPromise = waitForNamedDownload(recipientPage, attachment.fileName);
         
         // Click to download
         await attachmentLink.click();
@@ -692,7 +698,7 @@ test.describe('File Attachment Tests', () => {
     await expect(receivedAttachment).toHaveText(fileName);
 
     // Test download on third user's side
-    const downloadPromise = thirdUserPage.waitForEvent('download');
+    const downloadPromise = waitForNamedDownload(thirdUserPage, fileName);
     await receivedAttachment.click();
     await expect(thirdUserPage.locator('#imageAttachmentContextMenu .context-menu-option[data-action="save"]')).toBeVisible();
     await thirdUserPage.click('#imageAttachmentContextMenu .context-menu-option[data-action="save"]');


### PR DESCRIPTION
## What Changed

This PR makes attachment E2E tests capture the explicitly named download instead of the first browser download event.

- `waitForNamedDownload` filters download events by the expected `suggestedFilename()`.
- Own, recipient, multiple, and shared attachment flows use the same event handling.
- Existing filename, file existence, size, and byte-for-byte content assertions remain in place.

## Fixed Flow

1. A user saves an attachment from a chat.
2. Chromium may first emit a UUID-named download while opening a PDF blob in a new tab.
3. The test ignores that event and continues waiting for the original attachment filename.
4. The explicitly named download is saved and validated by the existing assertions.

## Why

The tests previously accepted the first download event even though browser-viewable attachments intentionally open in a tab and download a named local copy. Filtering at the event boundary keeps the test aligned with that dual behavior and prevents the PDF preview event from being mistaken for the saved attachment.

## Validation

- `node --check tests/attachments.e2e.test.js`
- `npm test -- tests/attachments.e2e.test.js --list`
- `CI=1 npx playwright test tests/attachments.e2e.test.js --project=chromium --grep "download own|recipient receives|multiple attachments|share attachment" --reporter=line --retries=0` (4 passed)

Closes #63