### PR TITLE
Make friend-status E2E helpers idempotent

### DIFF
--- a/playwright-tests/helpers/friendStatusHelpers.js
+++ b/playwright-tests/helpers/friendStatusHelpers.js
@@ -1,4 +1,5 @@
 const { expect } = require('@playwright/test');
+const { getInjectedTransaction } = require('./injectHelpers');
 
 const FriendStatus = Object.freeze({
   BLOCKED: 0,
@@ -6,11 +7,171 @@ const FriendStatus = Object.freeze({
   CONNECTION: 2,
 });
 
-async function waitForFriendStatusTransaction(page) {
-  await page.waitForEvent('console', {
-    timeout: 60_000,
-    predicate: (msg) => /update_toll_required transaction successfully processed/i.test(msg.text()),
+const FRIEND_STATUS_LABELS = Object.freeze({
+  [FriendStatus.BLOCKED]: 'Blocked',
+  [FriendStatus.OTHER]: 'Tolled',
+  [FriendStatus.CONNECTION]: 'Connection',
+});
+
+const FRIEND_STATUS_STATE_TIMEOUT = 15_000;
+const FRIEND_STATUS_SETTLEMENT_TIMEOUT = 60_000;
+const USABLE_FRIEND_STATUS_STATES = new Set(['ready', 'offline', 'failed', 'pending']);
+
+function isFriendStatusInjection(response) {
+  return getInjectedTransaction(response.request())?.type === 'update_toll_required';
+}
+
+async function readFriendStatusState(page) {
+  const modal = page.locator('#friendModal');
+  const declaredState = await modal.getAttribute('data-status-state');
+  if (USABLE_FRIEND_STATUS_STATES.has(declaredState)) {
+    return declaredState;
+  }
+
+  const firstStatusInput = page.locator('#friendForm input[name="friendStatus"]').first();
+  if (await firstStatusInput.isEnabled()) {
+    return 'ready';
+  }
+
+  const refreshMessage = page.locator('#friendStatusRefreshMessage');
+  if (await refreshMessage.isVisible()) {
+    const message = await refreshMessage.textContent();
+    if (/offline/i.test(message)) return 'offline';
+    if (/could not refresh|failed/i.test(message)) return 'failed';
+    if (/pending/i.test(message)) return 'pending';
+  }
+
+  return 'checking';
+}
+
+async function waitForFriendStatusState(page) {
+  let currentState = 'checking';
+
+  await expect.poll(async () => {
+    currentState = await readFriendStatusState(page);
+    return currentState;
+  }, {
+    message: 'Contact Status did not finish refreshing',
+    timeout: FRIEND_STATUS_STATE_TIMEOUT,
+  }).not.toBe('checking');
+
+  return currentState;
+}
+
+function readStatusFromButtonClass(className) {
+  const match = className.match(/(?:^|\s)status-([012])(?:\s|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+async function openFriendStatusModal(page, openButton) {
+  const modal = page.locator('#friendModal');
+  await openButton.click();
+
+  if (await modal.isVisible()) {
+    return 'open';
+  }
+
+  const pendingToast = page.locator('.toast.warning.show', {
+    hasText: /pending transaction.*friend status/i,
   });
+  await expect(pendingToast).toBeVisible({ timeout: 5_000 }).catch(() => {
+    throw new Error('Contact Status did not open and no pending-status warning was shown');
+  });
+  return 'pending';
+}
+
+async function closeFriendStatusModal(page) {
+  await page.locator('#closeFriendModal').click();
+  await expect(page.locator('#friendModal')).not.toHaveClass(/active/);
+}
+
+function friendStatusUnavailableError(state, status) {
+  const requestedStatus = FRIEND_STATUS_LABELS[status] || String(status);
+  return new Error(`Cannot change Contact Status to ${requestedStatus} while the modal is ${state}`);
+}
+
+async function getAcceptedFriendStatusTxid(response, status) {
+  const result = await response.json();
+  const success = result?.result?.success ?? result?.success;
+  if (success !== true) {
+    const reason = result?.result?.reason || result?.reason || 'unknown reason';
+    throw new Error(`Contact Status ${FRIEND_STATUS_LABELS[status]} injection failed: ${reason}`);
+  }
+
+  const txid = result?.result?.txId || result?.result?.txid || result?.txId || result?.txid;
+  if (!txid) {
+    throw new Error(`Contact Status ${FRIEND_STATUS_LABELS[status]} injection returned no transaction ID`);
+  }
+
+  return txid;
+}
+
+async function waitForFriendStatusSettlement(page, status, txid) {
+  let response;
+  try {
+    response = await page.waitForResponse(async (candidate) => {
+      const url = candidate.url();
+      const matchesTransaction = url.includes(`/transaction/${txid}`)
+        || (url.includes('/collector/api/transaction') && url.includes(`appReceiptId=${txid}`));
+      if (!matchesTransaction) {
+        return false;
+      }
+
+      try {
+        const body = await candidate.json();
+        return body?.transaction?.success === true || body?.transaction?.success === false;
+      } catch {
+        return false;
+      }
+    }, { timeout: FRIEND_STATUS_SETTLEMENT_TIMEOUT });
+  } catch {
+    throw new Error(`Contact Status ${FRIEND_STATUS_LABELS[status]} did not settle within 60 seconds`);
+  }
+
+  const result = await response.json();
+  if (result.transaction?.success !== true) {
+    const reason = result.transaction?.reason || 'unknown reason';
+    throw new Error(`Contact Status ${FRIEND_STATUS_LABELS[status]} failed to settle: ${reason}`);
+  }
+}
+
+async function updateFriendStatus(page, openButton, status) {
+  const openResult = await openFriendStatusModal(page, openButton);
+  if (openResult === 'pending') {
+    const currentStatus = readStatusFromButtonClass(await openButton.getAttribute('class') || '');
+    if (currentStatus === status) {
+      return;
+    }
+    throw friendStatusUnavailableError('pending', status);
+  }
+
+  const state = await waitForFriendStatusState(page);
+  const checkedStatus = Number(await page
+    .locator('#friendForm input[name="friendStatus"]:checked')
+    .getAttribute('value'));
+
+  if (checkedStatus === status) {
+    await closeFriendStatusModal(page);
+    return;
+  }
+
+  if (state !== 'ready') {
+    throw friendStatusUnavailableError(state, status);
+  }
+
+  const statusInput = page.locator(`#friendForm input[name="friendStatus"][value="${status}"]`);
+  const submitButton = page.locator('#friendForm button[type="submit"]');
+  await statusInput.check();
+  await expect(submitButton).toBeEnabled();
+
+  const injectionPromise = page.waitForResponse(isFriendStatusInjection);
+  await submitButton.click();
+  const txid = await getAcceptedFriendStatusTxid(await injectionPromise, status);
+
+  const settlementPromise = waitForFriendStatusSettlement(page, status, txid);
+  await expect(page.locator('#friendModal')).not.toHaveClass(/active/);
+  await settlementPromise;
+  await expect(openButton).toHaveClass(new RegExp(`\\bstatus-${status}\\b`));
 }
 
 async function setFriendStatus(page, username, status) {
@@ -20,14 +181,8 @@ async function setFriendStatus(page, username, status) {
   await expect(page.locator('#contactsScreen.active')).toBeVisible();
   await page.locator('#contactsList .chat-name', { hasText: username }).click();
   await expect(page.locator('#contactInfoModal.active')).toBeVisible();
-  await page.locator('#addFriendButtonContactInfo').click();
-  await expect(page.locator('#friendModal.active')).toBeVisible();
-  await page.locator(`#friendForm input[type=radio][value="${status}"]`).check();
 
-  await Promise.all([
-    waitForFriendStatusTransaction(page),
-    page.locator('#friendForm button[type="submit"]').click(),
-  ]);
+  await updateFriendStatus(page, page.locator('#addFriendButtonContactInfo'), status);
 
   await page.locator('#closeContactInfoModal').click();
   await expect(page.locator('#contactInfoModal')).not.toHaveClass(/active/);
@@ -36,20 +191,11 @@ async function setFriendStatus(page, username, status) {
 async function setFriendStatusInChat(page, status) {
   // Use the chat header button when the caller already has the relevant chat
   // modal open and wants to keep working in that conversation.
-  await page.locator('#addFriendButtonChat').click();
-  await expect(page.locator('#friendModal.active')).toBeVisible();
-  await page.locator(`#friendForm input[type=radio][value="${status}"]`).check();
-
-  await Promise.all([
-    waitForFriendStatusTransaction(page),
-    page.locator('#friendForm button[type="submit"]').click(),
-  ]);
-
-  await expect(page.locator('#friendModal')).not.toHaveClass(/active/);
+  await updateFriendStatus(page, page.locator('#addFriendButtonChat'), status);
 }
 
 async function getCurrentFriendStatus(page, username) {
-  // Open the friend modal just long enough to read the selected radio value,
+  // Open the friend modal just long enough to read the refreshed radio value,
   // then return the page to its previous modal-free state.
   await page.locator('#switchToContacts').click();
   await expect(page.locator('#contactsScreen.active')).toBeVisible();
@@ -57,10 +203,11 @@ async function getCurrentFriendStatus(page, username) {
   await expect(page.locator('#contactInfoModal.active')).toBeVisible();
   await page.locator('#addFriendButtonContactInfo').click();
   await expect(page.locator('#friendModal.active')).toBeVisible();
+  await waitForFriendStatusState(page);
 
-  const checked = await page.locator('#friendForm input[type=radio]:checked').getAttribute('value');
+  const checked = await page.locator('#friendForm input[name="friendStatus"]:checked').getAttribute('value');
 
-  await page.locator('#closeFriendModal').click();
+  await closeFriendStatusModal(page);
   await page.locator('#closeContactInfoModal').click();
   await expect(page.locator('#contactInfoModal')).not.toHaveClass(/active/);
 

--- a/playwright-tests/helpers/injectHelpers.js
+++ b/playwright-tests/helpers/injectHelpers.js
@@ -1,3 +1,16 @@
+function getInjectedTransaction(request) {
+  if (request.method() !== 'POST' || !request.url().endsWith('/inject')) {
+    return null;
+  }
+
+  try {
+    const body = request.postDataJSON();
+    return typeof body.tx === 'string' ? JSON.parse(body.tx) : body.tx;
+  } catch {
+    return null;
+  }
+}
+
 async function holdNextInject(page, responseBody) {
   await page.evaluate((mockResponseBody) => {
     if (!window.__injectMockOriginalFetch) {
@@ -84,5 +97,6 @@ function failedInjectResponse(reason = 'forced_inject_failure') {
 
 module.exports = {
   failedInjectResponse,
+  getInjectedTransaction,
   holdNextInject,
 };

--- a/playwright-tests/tests/friendStatus.e2e.test.js
+++ b/playwright-tests/tests/friendStatus.e2e.test.js
@@ -2,6 +2,7 @@ const { test: base, expect } = require('../fixtures/base');
 const { createAndSignInUser, generateUsername } = require('../helpers/userHelpers');
 const { getLiberdusBalance } = require('../helpers/walletHelpers');
 const { FriendStatus, getCurrentFriendStatus, setFriendStatus } = require('../helpers/friendStatusHelpers');
+const { getInjectedTransaction } = require('../helpers/injectHelpers');
 const { sendMessageTo } = require('../helpers/messageHelpers');
 const networkParams = require('../helpers/networkParams');
 const { newContext } = require('../helpers/toastHelpers');
@@ -115,6 +116,27 @@ test.describe('Friend Status E2E', () => {
         ]);
         expect(checkedA).toBe(FriendStatus.OTHER);
         expect(checkedB).toBe(FriendStatus.CONNECTION);
+    });
+
+    test('Setting the current friend status does not inject a transaction', async ({ users }) => {
+        const { a, b } = users;
+        const friendStatusInjections = [];
+        const captureFriendStatusInjection = (request) => {
+            const transaction = getInjectedTransaction(request);
+            if (transaction?.type === 'update_toll_required') {
+                friendStatusInjections.push(transaction);
+            }
+        };
+
+        a.page.on('request', captureFriendStatusInjection);
+        try {
+            await setFriendStatus(a.page, b.username, FriendStatus.OTHER);
+        } finally {
+            a.page.off('request', captureFriendStatusInjection);
+        }
+
+        expect(friendStatusInjections).toHaveLength(0);
+        expect(await getCurrentFriendStatus(a.page, b.username)).toBe(FriendStatus.OTHER);
     });
 
     test('Block: known blocked state rejects without creating a message', async ({ users }) => {


### PR DESCRIPTION
## What changed

- Made both friend-status setup helpers wait for the Contact Status refresh state before reading or editing.
- Treat an already-selected status as a successful no-op, including read-only pending/offline/failed states.
- Replaced the debug-console wait with inject-response validation and receipt tracking by the returned transaction ID.
- Added a regression test proving that selecting the current status sends no `update_toll_required` transaction.
- Reused one inject-payload parser across the helper and regression test.

## Fixed flow

1. Open Contact Status from either Contact Info or the active chat.
2. Wait until the modal is ready, offline, failed, or pending.
3. Read the refreshed selected status.
4. If it already matches, close and continue without submitting.
5. If it differs, require the ready state, select the requested status, and submit.
6. Validate that injection was accepted and capture its transaction ID.
7. Follow that exact transaction to a successful receipt, then verify the visible status class.

## Why

The previous helper assumed every call created a transaction and waited for a debug console message. When the network refresh selected the desired value, Save correctly remained disabled and no transaction existed, so reaction and video-call setup timed out despite already being in the required state.

This draft is stacked on #71 so its diff contains only the issue #68 work.

## Validation

- Idempotence regression: 1 passed — zero status-update injects
- Real Other → Blocked change: 1 passed — accepted inject and successful receipt
- Targeted reaction flow: 1 passed
- Targeted video-call flow: 1 passed
- `node --check` for all changed JavaScript files
- `git diff --check`

Closes #68