### PR TITLE
Align scheduled-call E2E with the shared date/time picker

### DIFF
--- a/playwright-tests/tests/videoCall.e2e.test.js
+++ b/playwright-tests/tests/videoCall.e2e.test.js
@@ -136,8 +136,9 @@ test.describe('Video Call Tests', () => {
         await expect(a.page.locator('#callScheduleChoiceModal.active')).toBeVisible();
         await a.page.click('#openCallScheduleDateBtn');
 
-        const scheduleModal = a.page.locator('#callScheduleDateModal.active');
-        await expect(scheduleModal).toBeVisible();
+        const dateTimePicker = a.page.locator('#dateTimePickerModal.active');
+        await expect(dateTimePicker).toBeVisible();
+        await expect(dateTimePicker.locator('#dateTimePickerModalTitle')).toHaveText('Schedule Call');
 
         // Choose a schedule time two hours in the future, rounded to the hour for available options.
         const scheduleDate = new Date(Date.now() + 2 * 60 * 60 * 1000);
@@ -153,21 +154,19 @@ test.describe('Video Call Tests', () => {
         const hourSelectValue = hour12.toString().padStart(2, '0');
         const minuteSelectValue = scheduleDate.getMinutes().toString().padStart(2, '0');
         const datePart = `${month}/${day}/${year}`;
-        // Toast time part is like 2:00:00 PM (with seconds)
         const timePart = `${hour12}:${minuteSelectValue} ${amPm}`;
 
-        await scheduleModal.locator('#callScheduleDate').fill(dateInputValue);
-        await scheduleModal.locator('#callScheduleHour').selectOption(hourSelectValue);
-        await scheduleModal.locator('#callScheduleMinute').selectOption(minuteSelectValue);
-        await scheduleModal.locator('#callScheduleAmPm').selectOption(amPm);
+        await dateTimePicker.locator('#dateTimePickerDate').fill(dateInputValue);
+        await dateTimePicker.locator('#dateTimePickerHour').selectOption(hourSelectValue);
+        await dateTimePicker.locator('#dateTimePickerMinute').selectOption(minuteSelectValue);
+        await dateTimePicker.locator('#dateTimePickerAmPm').selectOption(amPm);
 
-        await scheduleModal.locator('#confirmCallSchedule').click();
+        await dateTimePicker.locator('#confirmDateTimePicker').click();
 
         const successToast = a.page.locator('.toast.success.show');
         await expect(successToast).toContainText('Call scheduled for', { timeout: 20_000 });
         await expect(successToast).toContainText(datePart);
-        const toastTimePart = `${hour12}:${minuteSelectValue}:00 ${amPm}`;
-        await expect(successToast).toContainText(toastTimePart);
+        await expect(successToast).toContainText(timePart);
         await a.page.waitForSelector('.toast.success.show', { state: 'hidden' });
 
         // Verify the scheduled call message on the sender side.


### PR DESCRIPTION
## What Changed

This PR aligns the scheduled video-call E2E flow with the shared date/time picker used by the current dev client.

- Waits for `dateTimePickerModal` and verifies its contextual title is **Schedule Call**.
- Uses the shared date, hour, minute, AM/PM, and confirmation controls.
- Matches the current minute-precision success toast and reuses that expected time for downstream message and call-list assertions.

## Fixed Flow

1. Set up the users and open the call scheduling choices.
2. Choose **Schedule**.
3. Wait for the shared date/time picker, verify its call-specific title, fill the shared controls, and submit.
4. Verify the success toast, sender and recipient scheduled messages, and both users' call lists.

## Why

The test still targeted the previous call-specific picker IDs even though the dev client now opens a shared date/time picker. The dialog was open, but the obsolete locator reported it as missing. The current client also displays scheduled times to the minute rather than including seconds.

This replaces #75, which was merged into an already-merged parent branch and therefore never reached `main`.

## Validation

- `CI=true npx playwright test tests/videoCall.e2e.test.js --project=chromium --grep "schedule call: scheduled message appears and call listed for both users" --workers=1 --retries=0 --reporter=line`
- `node --check tests/videoCall.e2e.test.js`
- `git diff --check origin/main...HEAD`

Closes #74